### PR TITLE
Chore: Update deployment file, add git reset

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
         echo "${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
         ssh-keyscan -H ${{ secrets.DEPLOY_SSH_HOST }} > ~/.ssh/known_hosts
     - name: connect and pull
-      run: ssh ${{ secrets.DEPLOY_SSH_USER }}@${{ secrets.DEPLOY_SSH_HOST }} "cd ${{ secrets.DEPLOY_WORK_DIR }} && git checkout ${{ secrets.DEPLOY_MAIN_BRANCH }} && git pull && exit"
+      run: ssh ${{ secrets.DEPLOY_SSH_USER }}@${{ secrets.DEPLOY_SSH_HOST }} "cd ${{ secrets.DEPLOY_WORK_DIR }} && git reset --hard && git checkout ${{ secrets.DEPLOY_MAIN_BRANCH }} && git pull && exit"
     - name: execute post tasks
       run: ssh ${{ secrets.DEPLOY_SSH_USER }}@${{ secrets.DEPLOY_SSH_HOST }} "cd ${{ secrets.DEPLOY_WORK_DIR }} && cd ../. && ./deploy_post.sh && exit"
     - name: cleanup


### PR DESCRIPTION
Chore: Update deployment file, add git reset
Git action will fail if "git checkout" is executed before doing a "git reset --hard" due to the package-lock.json file being updated with the "npm update" command.  This file will not be in sync with the repository and require a "git reset --hard" to bring it back into sync before a pull/checkout.